### PR TITLE
fixed bug that prevents plot saving if file name (not path) is given …

### DIFF
--- a/pycity_calc/visualization/city_visual.py
+++ b/pycity_calc/visualization/city_visual.py
@@ -593,9 +593,8 @@ def plot_city_district(city, city_list=None, plot_buildings=True,
                 except:
                     warnings.warn('Could not save figure as tikz')
 
-            elif os.path.isfile(save_path):
-
-                plt.savefig(save_path)
+            else:
+                plt.savefig(save_path, dpi=dpi)
 
     if show_plot:
         plt.show()


### PR DESCRIPTION
In `plot_city_district` if you choose the filename (instead of the path) and the file does not exist already, the figure will not be saved e.g. if `test.png` does not exist in the current directory:
```python
plot_city_district(city_obj,
                           save_plot=True,
                           save_path="test.png",
                           dpi=300)
```
This will not save the figure.
This fixes the issue and also gives the savefig command the dpi number.